### PR TITLE
Manifest: bump FD.o SDK to 24.08

### DIFF
--- a/com.endlessnetwork.fablemaker.json
+++ b/com.endlessnetwork.fablemaker.json
@@ -1,7 +1,7 @@
 {
   "id": "com.endlessnetwork.fablemaker",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "23.08",
+  "runtime-version": "24.08",
   "sdk": "org.freedesktop.Sdk",
   "build-options": {
     "strip": true,


### PR DESCRIPTION
Opening to make sure things still work against a newer runtime. Fixes #7.